### PR TITLE
allow it to match class methods and methods defined using define_method in ruby

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -46,6 +46,7 @@ module.exports =
     regex: [
       "(^|\\s)class\\s+{word}(\\s|$)"
       "(^|\\s)module\\s+{word}(\\s|$)"
-      "(^|\\s)def\\s+{word}\\s*\\("
+      "(^|\\s)def\\s+(?:self\\.)?{word}\\s*\\(?"
+      "(^|\\s)define_method\\s+:?{word}\\s*\\(?"
     ]
     type: ["*.rb"]


### PR DESCRIPTION
In ruby, you can also define class methods and instance methods using `define_method` - this modifies the regex to allow for both those cases.
