### PR TITLE
TypeScript support

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -18,6 +18,16 @@ module.exports =
     ]
     type: ["*.coffee", "*.js", "*.html"]
 
+  TypeScript:
+    regex: [
+      "(^|\\s)class\\s+{word}(\\s|$)"
+      "(^|\\s|\\.){word}\\s*[:=]\\s*(\\([\\s\\S]*?\\))?\\s*[=-]>"
+      "(^|\\s|\\.){word}\\s*[:=]\\s*function\\s*\\(" # JavaScript Function
+      "(^|\\s)function\\s+{word}\\s*\\("
+      "(^|\\s){word}\\([\\s\\S]*?\\)\\s*{"  # ES6
+    ]
+    type: ["*.ts", "*.html"]
+
   Python:
     regex: [
       "(^|\\s)class\\s+{word}\\s*\\("

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goto-definition",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "Goto definition.",
   "main": "./lib/goto-definition",
   "dependencies": {


### PR DESCRIPTION
I'm no expert with regexes; just copied the CoffeeScript regex over to TypeScript.  I originally include JS files in the reference search, but this gave a dropdown with a list of files.  I thought it'd just be better to directly jump into a TypeScript file without having to select from a dropdown.
