### PR TITLE
support(cpp): adds support for `.cxx` files in C++

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -142,7 +142,7 @@ export default {
       /(^|\s)filesdef\s.*(\s|\*|\(){word}(\s|;|\)|$)/,
       /(^|\s|\*|:|&){word}\s*\(.*\)(\s*|\s*const\s*)(\{|$)/,
     ],
-    files: ['*.c', '*.cc', '*.cpp', '*.h', '*.hh', '*.hpp', '*.inc'],
+    files: ['*.c', '*.cc', '*.cpp', '*.cxx', '*.h', '*.hh', '*.hpp', '*.inc'],
   },
 
   Shell: {


### PR DESCRIPTION
Simple change to add support for `*.cxx` files as C++ source code files.