### PR TITLE
Updated searcher.js to cater for Windows paths

### DIFF
--- a/lib/searcher.js
+++ b/lib/searcher.js
@@ -98,6 +98,12 @@ export default class Searcher {
         iterator(results.split('\n').map((result) => {
           if (result.trim().length) {
             const data = result.split(':');
+            // Windows filepath will become ['C','Windows/blah'], so this fixes it.
+            if (data[0].length === 1) {
+              const driveLetter = data.shift();
+              const path = data.shift();
+              data.unshift(`${driveLetter}:${path}`);
+            }
             return {
               text: result.substring([data[0], data[1], data[2]].join(':').length + 1),
               fileName: data[0],


### PR DESCRIPTION
Windows paths contain semicolon (e.g. C:\Windows), while searcher.js has to split at colon, since rg uses it as separator for path, line, column, code.
If the first array element has a length of 1, it can safely be assumed that it's a Windows path, so concatenate the first and second elements. 
(In Linux, this will not be a problem as the minimum path is e.g. '/a' so the length will be at least 2).