### PR TITLE
Allow jumping to Ruby constant definitions

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -101,6 +101,7 @@ export default {
       /(^|\s)attr_reader\s+:{word}(\s|$)/,
       /(^|\s)attr_writer\s+:{word}(\s|$)/,
       /(^|\s)define_method\s+:?{word}\s*\(?/,
+      /(^|\s){word}\s*=(\s|$)/,
     ],
     files: ['*.rb', '*.ru', '*.haml', '*.erb', '*.rake'],
   },


### PR DESCRIPTION
This will allow us to jump from `MY_CONSTANT` to:

    MY_CONSTANT = 2
    MY_CONSTANT=2

Upside: It will also enable the ability to jump from a constant (or variable) to it's declaration. 
Downside: It will find all variable declarations with the same name.