### PR TITLE
Added support for the Nim programming language.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -163,4 +163,15 @@ export default {
     ],
     files: ['*.sh'],
   },
+
+  Nim: {
+      word: /[0-9a-zA-Z_]+/,
+      regexes: [
+          /(^|\s)proc\s+{word}/,
+          /(^|\s)template\s+{word}/,
+          /(^|\s)macro\s+{word}/,
+          /(^|\s)block\s+{word}/
+      ],
+      files: ['*.nim']
+  }
 };


### PR DESCRIPTION
I added support for the Nim programming language.

It supports finding `proc`, `template`, `macro`, and `block` definitions.

I couldn't think of regex that would let me match `var`, `const`, or `type` definitions like this:

    type
      TestType = ref object
      TestTypeObj = object

and match both TestType and TestTypeObj without including a bunch of non-definitions. If anyone has any ideas, let me know. Type definition would be really useful.